### PR TITLE
Feature/character api

### DIFF
--- a/larpmanager/urls/orga.py
+++ b/larpmanager/urls/orga.py
@@ -1126,4 +1126,9 @@ urlpatterns = [
         views_ox.orga_api_px_ability_templates,
         name="orga_api_px_ability_templates",
     ),
+    path(
+        "api/<slug:s>/<int:n>/manage/ci/pool_types/",
+        views_ci.orga_api_ci_pool_types,
+        name="orga_api_ci_pool_types",
+    ),
 ]

--- a/larpmanager/urls/orga.py
+++ b/larpmanager/urls/orga.py
@@ -1116,4 +1116,14 @@ urlpatterns = [
         views_ox.orga_api_px_abilities,
         name="orga_api_px_abilities",
     ),
+    path(
+        "api/<slug:s>/<int:n>/manage/px/ability_types/",
+        views_ox.orga_api_px_ability_types,
+        name="orga_api_px_ability_types",
+    ),
+    path(
+        "api/<slug:s>/<int:n>/manage/px/ability_templates/",
+        views_ox.orga_api_px_ability_templates,
+        name="orga_api_px_ability_templates",
+    ),
 ]

--- a/larpmanager/urls/orga.py
+++ b/larpmanager/urls/orga.py
@@ -1107,6 +1107,11 @@ urlpatterns = [
         name="orga_inventory_assignment_item_edit",
     ),
     path(
+        "api/<slug:s>/<int:n>/manage/characters/",
+        views_oc.orga_api_characters,
+        name="orga_api_characters",
+    ),
+    path(
         "api/<slug:s>/<int:n>/manage/px/abilities/",
         views_ox.orga_api_px_abilities,
         name="orga_api_px_abilities",

--- a/larpmanager/urls/orga.py
+++ b/larpmanager/urls/orga.py
@@ -1106,4 +1106,9 @@ urlpatterns = [
         views_oms.orga_inventory_assignment_item_edit,
         name="orga_inventory_assignment_item_edit",
     ),
+    path(
+        "api/<slug:s>/<int:n>/manage/px/abilities/",
+        views_ox.orga_api_px_abilities,
+        name="orga_api_px_abilities",
+    ),
 ]

--- a/larpmanager/urls/user.py
+++ b/larpmanager/urls/user.py
@@ -405,6 +405,16 @@ urlpatterns = [
         name="character_customize",
     ),
     path(
+        "<slug:s>/<int:n>/character/list/data/",
+        views_uc.character_list_data,
+        name="character_list_data"
+    ),
+    path(
+        "<slug:s>/<int:n>/character/<int:num>/data/",
+        views_uc.character_data,
+        name="character_data"
+    ),
+    path(
         "<slug:s>/<int:n>/character/<int:num>/profile/rotate/<int:r>/",
         views_uc.character_profile_rotate,
         name="character_profile_rotate",

--- a/larpmanager/urls/user.py
+++ b/larpmanager/urls/user.py
@@ -405,16 +405,6 @@ urlpatterns = [
         name="character_customize",
     ),
     path(
-        "<slug:s>/<int:n>/character/list/data/",
-        views_uc.character_list_data,
-        name="character_list_data"
-    ),
-    path(
-        "<slug:s>/<int:n>/character/<int:num>/data/",
-        views_uc.character_data,
-        name="character_data"
-    ),
-    path(
         "<slug:s>/<int:n>/character/<int:num>/profile/rotate/<int:r>/",
         views_uc.character_profile_rotate,
         name="character_profile_rotate",
@@ -729,4 +719,14 @@ urlpatterns = [
         name="tutorial_query",
     ),
     path("upload_image/", views_base.upload_image, name="upload_image"),
+    path(
+        "api/<slug:s>/<int:n>/character/list/",
+        views_uc.api_character_list,
+        name="api_character_list"
+    ),
+    path(
+        "api/<slug:s>/<int:n>/character/<int:num>/",
+        views_uc.api_character,
+        name="api_character"
+    ),
 ]

--- a/larpmanager/views/orga/characterinventory.py
+++ b/larpmanager/views/orga/characterinventory.py
@@ -19,6 +19,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import models
+from django.http import JsonResponse
 from django.shortcuts import redirect, render, get_object_or_404
 from django.views.decorators.http import require_POST
 
@@ -117,3 +118,15 @@ def orga_ci_transfer(request, s, n):
 
     redirect_pk = source_inventory.id if source_inventory else (target_inventory.id if target_inventory else 0)
     return redirect("orga_ci_character_inventory_view", s=s, n=n, num=redirect_pk)
+
+
+@login_required
+def orga_api_ci_pool_types(request, s, n):
+    ctx = check_event_permission(request, s, n, "orga_ci_pool_types")
+    ctx["list"] = ctx["event"].get_elements(PoolTypeCI).order_by("number")
+
+    parsed_types = []
+    for type in ctx["list"]:
+        parsed_types.append({"id": type.pk, "name": type.name})
+
+    return JsonResponse(parsed_types, safe=False)

--- a/larpmanager/views/orga/experience.py
+++ b/larpmanager/views/orga/experience.py
@@ -19,6 +19,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR Proprietary
 
 from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
 from django.shortcuts import redirect, render
 
 from larpmanager.forms.experience import OrgaAbilityPxForm, OrgaAbilityTypePxForm, OrgaDeliveryPxForm, OrgaRulePxForm, \
@@ -95,3 +96,18 @@ def orga_px_rules_order(request, s, n, num, order):
     ctx = check_event_permission(request, s, n, "orga_px_rules")
     exchange_order(ctx, RulePx, num, order)
     return redirect("orga_px_rules", s=ctx["event"].slug, n=ctx["run"].number)
+
+@login_required
+def orga_api_px_abilities(request, s, n):
+    ctx = check_event_permission(request, s, n, "orga_px_abilities")
+    ctx["px_user"] = ctx["event"].get_config("px_user", False)
+    ctx["list"] = ctx["event"].get_elements(AbilityPx).order_by("number")
+
+    parsed_abilities = []
+    for ability in ctx["list"]:
+        if ability.template == None:
+            ability_template = {}
+        else:
+            ability_template = {"id": ability.template.pk, "name": ability.template.name}
+        parsed_abilities.append({"id": ability.pk, "name": ability.name, "type": {"id": ability.typ.pk, "name": ability.typ.name}, "template": ability_template})
+    return JsonResponse(parsed_abilities, safe=False)

--- a/larpmanager/views/orga/experience.py
+++ b/larpmanager/views/orga/experience.py
@@ -97,6 +97,7 @@ def orga_px_rules_order(request, s, n, num, order):
     exchange_order(ctx, RulePx, num, order)
     return redirect("orga_px_rules", s=ctx["event"].slug, n=ctx["run"].number)
 
+
 @login_required
 def orga_api_px_abilities(request, s, n):
     ctx = check_event_permission(request, s, n, "orga_px_abilities")
@@ -110,4 +111,29 @@ def orga_api_px_abilities(request, s, n):
         else:
             ability_template = {"id": ability.template.pk, "name": ability.template.name}
         parsed_abilities.append({"id": ability.pk, "name": ability.name, "type": {"id": ability.typ.pk, "name": ability.typ.name}, "template": ability_template})
+
     return JsonResponse(parsed_abilities, safe=False)
+
+
+@login_required
+def orga_api_px_ability_types(request, s, n):
+    ctx = check_event_permission(request, s, n, "orga_px_abilities")
+    ctx["list"] = ctx["event"].get_elements(AbilityTypePx).order_by("number")
+
+    parsed_types = []
+    for type in ctx["list"]:
+        parsed_types.append({"id": type.pk, "name": type.name})
+
+    return JsonResponse(parsed_types, safe=False)
+
+
+@login_required
+def orga_api_px_ability_templates(request, s, n):
+    ctx = check_event_permission(request, s, n, "orga_px_abilities")
+    ctx["list"] = ctx["event"].get_elements(AbilityTemplatePx).order_by("number")
+
+    parsed_templates = []
+    for template in ctx["list"]:
+        parsed_templates.append({"id": template.pk, "name": template.name})
+
+    return JsonResponse(parsed_templates, safe=False)

--- a/larpmanager/views/user/character.py
+++ b/larpmanager/views/user/character.py
@@ -598,12 +598,18 @@ def api_character(request, s, n, num):
 
     parsed_abilities = {}
     for ability in abilities:
-        if ability.typ.name not in parsed_abilities:
-            parsed_abilities[ability.typ.name] = []
-        parsed_abilities[ability.typ.name].append({"name": ability.name, "template": ability.template.name})
+        if ability.typ.pk not in parsed_abilities.keys():
+            parsed_abilities[ability.typ.pk] = {"id": ability.typ.pk, "name": ability.typ.name, "abilities": []}
+
+        if ability.template == None:
+            ability_template = {}
+        else:
+            ability_template = {"id": ability.template.pk, "name": ability.template.name}
+
+        parsed_abilities[ability.typ.pk]["abilities"].append({"id": ability.pk, "name": ability.name, "template": ability_template})
 
     parsed_pools = []
     for pool in pools:
         parsed_pools.append({"type": pool["type"].name, "balance": pool["balance"].amount })
 
-    return JsonResponse({"id": id, "name": name, "abilities": parsed_abilities, "inventory": parsed_pools})
+    return JsonResponse({"id": id, "name": name, "ability_types": parsed_abilities, "inventory": parsed_pools})

--- a/larpmanager/views/user/character.py
+++ b/larpmanager/views/user/character.py
@@ -383,33 +383,6 @@ def character_edit(request, s, n, num):
     get_char_check(request, ctx, num, True)
     return character_form(request, ctx, s, n, ctx["character"], CharacterForm)
 
-@login_required
-def character_list_data(request, s, n):
-    ctx = get_event_run(request, s, n, status=True, signup=True, slug="user_character")
-
-    ctx["list"] = get_player_characters(request.user.member, ctx["event"])
-
-    charList = []
-
-    for char in ctx["list"]:
-        charList.append({"id": char["px"], "name": char["name"]})
-
-    return JsonResponse(charList)
-
-@login_required
-def character_data(request, s, n, num):
-    ctx = get_event_run(request, s, n, status=True, signup=True)
-    get_char_check(request, ctx, num, True)
-    get_character_inventory(ctx, num)
-    get_event_cache_all(ctx)
-
-    id = ctx["character"].pk
-    name = ctx["character"].name
-    abilities = ctx["character"].px_ability_list.all()
-    inventory = ctx["character"].character_inventory.get_pool_balances()
-
-    return JsonResponse({"id": id, "name": name, "abilities": abilities, "inventory": inventory})
-
 
 def get_options_dependencies(ctx):
     ctx["dependencies"] = {}
@@ -591,3 +564,31 @@ def show_char(request, s, n):
     ch = ctx["chars"][search]
     tooltip = get_tooltip(ctx, ch)
     return JsonResponse({"content": f"<div class='show_char'>{tooltip}</div>"})
+
+
+@login_required
+def api_character_list(request, s, n):
+    ctx = get_event_run(request, s, n, status=True, signup=True, slug="user_character")
+
+    ctx["list"] = get_player_characters(request.user.member, ctx["event"])
+
+    charList = []
+
+    for char in ctx["list"]:
+        charList.append({"id": char["px"], "name": char["name"]})
+
+    return JsonResponse(charList)
+
+@login_required
+def api_character(request, s, n, num):
+    ctx = get_event_run(request, s, n, status=True, signup=True)
+    get_char_check(request, ctx, num, True)
+    get_character_inventory(ctx, num)
+    get_event_cache_all(ctx)
+
+    id = ctx["character"].pk
+    name = ctx["character"].name
+    abilities = ctx["character"].px_ability_list.all()
+    inventory = ctx["character"].character_inventory.get_pool_balances()
+
+    return JsonResponse({"id": id, "name": name, "abilities": abilities, "inventory": inventory})

--- a/larpmanager/views/user/character.py
+++ b/larpmanager/views/user/character.py
@@ -70,6 +70,7 @@ from larpmanager.templatetags.show_tags import get_tooltip
 from larpmanager.utils.character import get_char_check, get_character_relationships, get_character_sheet
 from larpmanager.utils.common import (
     get_player_relationship,
+    get_character_inventory
 )
 from larpmanager.utils.edit import user_edit
 from larpmanager.utils.event import get_event_run
@@ -381,6 +382,33 @@ def character_edit(request, s, n, num):
     ctx = get_event_run(request, s, n, status=True, signup=True)
     get_char_check(request, ctx, num, True)
     return character_form(request, ctx, s, n, ctx["character"], CharacterForm)
+
+@login_required
+def character_list_data(request, s, n):
+    ctx = get_event_run(request, s, n, status=True, signup=True, slug="user_character")
+
+    ctx["list"] = get_player_characters(request.user.member, ctx["event"])
+
+    charList = []
+
+    for char in ctx["list"]:
+        charList.append({"id": char["px"], "name": char["name"]})
+
+    return JsonResponse(charList)
+
+@login_required
+def character_data(request, s, n, num):
+    ctx = get_event_run(request, s, n, status=True, signup=True)
+    get_char_check(request, ctx, num, True)
+    get_character_inventory(ctx, num)
+    get_event_cache_all(ctx)
+
+    id = ctx["character"].pk
+    name = ctx["character"].name
+    abilities = ctx["character"].px_ability_list.all()
+    inventory = ctx["character"].character_inventory.get_pool_balances()
+
+    return JsonResponse({"id": id, "name": name, "abilities": abilities, "inventory": inventory})
 
 
 def get_options_dependencies(ctx):


### PR DESCRIPTION
Adds two character endpoints:
 - GET /api/\<slug>/<#>/character/list/
   - Returns a list of the user's owned character's, similiar to /\<slug>/<#>/character/list, except as a JSON array of objects
   - Schema:
   ```
    [
        {
            "id": character.pk,
            "name": character.name
        },
        ...
    ]
 - GET /api/\<slug>/\<#>/character/\<id>/
    - Returns a particular user owned by the logged in user, similiar to /\<slug>/\<#>/character/\<id>/, except as a JSON object, including the character's abilities and inventory pools. Other characters return a 404.
    - Schema:
    ```
    {
        "id": character.pk,
        "name": character.name,
        "abilities":
        [
            {
                "id": ability_type.pk,
                "name": ability_type.name,
                "abilities":
                [
                    {
                        "id": ability.pk,
                        "name": ability.name,
                        "template":
                        {
                            "id": ability.template.pk,
                            "name": ability.template.name
                        }
                    },
                    ...
                ],
                "inventory":
                [
                    {
                        "type": pool_type.name,
                        "balance": pool_balance.amount
                    },
                    ...
                ]
            },
            ...
        ]
    }
Also, adds five admin orga endpoints:
 - GET /api/\<slug>/\<#>/manage/characters/
   - Returns the full list of characters, similar to \<slug>/\<#>/manage/characters/, except as a JSON array of objects, including abilities and inventory pools, the same way the /api/.../characters/\<id>/ endpoint does.

 - GET /api/\<slug>/\<#>/manage/pk/abilities
 - GET /api/\<slug>/\<#>/manage/pk/ability_types/
 - GET /api/\<slug>/\<#>/manage/pk/ability_templates/
 - GET /api/\<slug>/\<#>/manage/ci/pool_types/
   - Returns a JSON array of the requested objects, typically as just [ { "id": object.pk, "name": object.name }, ... ]
   - Abilities also include ability_type and template, similar to the character endpoints.